### PR TITLE
test: simple sanity test instead of error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,12 @@
   "name": "multitenancy",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "bin": {
     "mtm": "./manager.js",
     "mtg": "./gateway.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "author": "",
   "license": "Private",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var pkg = require('./package.json');
+
+if (pkg.main) {
+  // will throw and exception if it can't be found
+  require.resolve(pkg.main);
+}
+
+for (var b in pkg.bin) {
+  // will throw and exception if it can't be found
+  require.resolve(pkg.bin[b]);
+}


### PR DESCRIPTION
This is required for playing well in the StrongLoop upstream/downstream
continuous integration model.

Fixes #4
